### PR TITLE
Refactor plot view to function component

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -98,8 +98,8 @@ android {
         applicationId "com.jazeee"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 16
-        versionName "2.0.2"
+        versionCode 17
+        versionName "2.1.0"
     }
 
     splits {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jazeee",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jazeee",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "1.18.1",
         "@react-navigation/native": "6.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "JazCom Data Viewer - Plot data from API every 5 minutes or so.",
   "name": "jazeee",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -6,7 +6,7 @@ export function Home() {
   const { navigate } = useNavigation();
   return (
     <View style={styles.container}>
-      <Text style={styles.welcome}>Jazeee Data Monitor v2.0.2</Text>
+      <Text style={styles.welcome}>Jazeee Data Monitor v2.1.0</Text>
       <Text style={styles.description}>
         This application reads data from an API and displays it in an always-on
         graph.

--- a/src/PlotView/PlotView.tsx
+++ b/src/PlotView/PlotView.tsx
@@ -23,7 +23,7 @@ interface Props {
 
 interface State {
   readings?: IPlotDatum[];
-  response: string;
+  logContent: string;
   plotWidth: number;
   plotHeight: number;
   plotSettings: IPlotSettings;
@@ -38,7 +38,7 @@ class PlotView extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      response: '',
+      logContent: '',
       plotSettings: DEFAULT_META,
       plotWidth: 100,
       plotHeight: 100,
@@ -62,7 +62,7 @@ class PlotView extends Component<Props, State> {
       prevSettings.sourceUrl !== settings.sourceUrl
     ) {
       this.setState(
-        { readings: [], response: 'Loading...' },
+        { readings: [], logContent: 'Loading...' },
         this.getData.bind(this),
       );
     }
@@ -112,7 +112,7 @@ class PlotView extends Component<Props, State> {
         return;
       }
       this.setState({
-        response: 'Success',
+        logContent: 'Success',
         readings,
         plotSettings: meta,
       });
@@ -131,7 +131,7 @@ class PlotView extends Component<Props, State> {
       }
     } catch (error: any) {
       console.log(error);
-      this.setState({ response: error.toString() });
+      this.setState({ logContent: error.toString() });
       this.failureCount += 1;
     }
     if (this.lastTimeoutId !== 0) {
@@ -144,7 +144,7 @@ class PlotView extends Component<Props, State> {
   };
 
   render() {
-    const { readings, response, plotWidth, plotHeight, plotSettings } =
+    const { readings, logContent, plotWidth, plotHeight, plotSettings } =
       this.state;
     const [latestReading] = readings ?? [];
     const { Trend: trend, Value: latestValue } = latestReading ?? {};
@@ -180,8 +180,8 @@ class PlotView extends Component<Props, State> {
           trend={trend}
           readingIsOld={readingIsOld ?? false}
         />
-        <Text style={styles.response}>
-          {response}
+        <Text style={styles.logContent}>
+          {logContent}
           {readingIsOld && ' Outdated Reading'}
         </Text>
       </View>
@@ -243,7 +243,7 @@ export function WrappedPlotView() {
   if (apiUrlsAreLoading || authKeyIsLoading) {
     return (
       <View>
-        <Text style={styles.response}>Loading...</Text>
+        <Text style={styles.logContent}>Loading...</Text>
       </View>
     );
   }
@@ -275,7 +275,7 @@ const styles = StyleSheet.create({
     fontSize: 64,
     color: COLORS.primary,
   },
-  response: {
+  logContent: {
     fontSize: 16,
     color: COLORS.primary,
     position: 'absolute',

--- a/src/PlotView/PlotView.tsx
+++ b/src/PlotView/PlotView.tsx
@@ -9,7 +9,6 @@ import { Overlay } from './components/Overlay';
 import { playAudioIfNeeded } from './playAudio';
 import { isTestApi } from '../UserSettings/utils';
 import { useSettingsContext } from '../UserSettings/SettingsProvider';
-import { useNavigation } from '@react-navigation/native';
 import { IApiUrl, IPlotDatum, IPlotSettings } from './types';
 import { useQuery } from '@tanstack/react-query';
 
@@ -18,8 +17,6 @@ const plotMarginX2 = plotMargin * 2;
 const EXTRA_LATENCY_IN_SECONDS = 10 + 10 * Math.random();
 interface Props {
   settings: Record<string, string>;
-  // FIXME refactor
-  navigation: any;
   apiUrls: IApiUrl | undefined;
   authKey: string;
 }
@@ -193,7 +190,6 @@ class PlotView extends Component<Props, State> {
 }
 
 export function WrappedPlotView() {
-  const navigation = useNavigation();
   const { settings } = useSettingsContext();
   const { sourceUrl } = settings;
   const { data: apiUrls, isLoading: apiUrlsAreLoading } = useQuery({
@@ -252,12 +248,7 @@ export function WrappedPlotView() {
     );
   }
   return (
-    <PlotView
-      settings={settings}
-      navigation={navigation}
-      apiUrls={apiUrls}
-      authKey={authKey ?? ''}
-    />
+    <PlotView settings={settings} apiUrls={apiUrls} authKey={authKey ?? ''} />
   );
 }
 

--- a/src/PlotView/PlotView.tsx
+++ b/src/PlotView/PlotView.tsx
@@ -1,4 +1,4 @@
-import React, { Component, useState } from 'react';
+import { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 
 import { COLORS } from '../common/colors';

--- a/src/PlotView/PlotView.tsx
+++ b/src/PlotView/PlotView.tsx
@@ -28,7 +28,6 @@ interface State {
   timeSinceLastReadingInSeconds: number | undefined;
   readingIsOld: boolean | undefined;
   readings?: IPlotDatum[];
-  lastUrl: string;
   response: string;
   plotWidth: number;
   plotHeight: number;
@@ -46,7 +45,6 @@ class PlotView extends Component<Props, State> {
     this.state = {
       timeSinceLastReadingInSeconds: undefined,
       readingIsOld: undefined,
-      lastUrl: '',
       response: '',
       plotSettings: DEFAULT_META,
       plotWidth: 100,
@@ -95,7 +93,6 @@ class PlotView extends Component<Props, State> {
     let delayToNextRequestInSeconds = 5 * 60;
     try {
       const { data: dataReq, meta = DEFAULT_META } = apiUrls ?? ({} as IApiUrl);
-      this.setState({ lastUrl: dataReq.url });
       const postResult = await fetch(
         `${dataReq.url}?sessionId=${this.props.authKey}&minutes=1440&maxCount=100`,
         {
@@ -158,7 +155,6 @@ class PlotView extends Component<Props, State> {
   render() {
     const {
       readings,
-      lastUrl,
       response,
       readingIsOld,
       plotWidth,
@@ -198,7 +194,6 @@ class PlotView extends Component<Props, State> {
           readingIsOld={readingIsOld ?? false}
         />
         <Text style={styles.response}>
-          {response.includes('Error') ? lastUrl + ' ' : ''}
           {response}
           {readingIsOld && ' Outdated Reading'}
         </Text>

--- a/src/PlotView/PlotView.tsx
+++ b/src/PlotView/PlotView.tsx
@@ -16,7 +16,7 @@ const plotMargin = 4;
 const plotMarginX2 = plotMargin * 2;
 const EXTRA_LATENCY_IN_SECONDS = 10 + 10 * Math.random();
 interface Props {
-  state: Record<string, string>;
+  settings: Record<string, string>;
   // FIXME refactor
   navigation: any;
 }
@@ -68,12 +68,12 @@ class PlotView extends Component<Props, State> {
   };
 
   componentDidUpdate = (prevProps: Props) => {
-    const { state: prevState } = prevProps;
-    const { state } = this.props;
+    const { settings: prevSettings } = prevProps;
+    const { settings } = this.props;
     if (
-      prevState.username !== state.username ||
-      prevState.password !== state.password ||
-      prevState.sourceUrl !== state.sourceUrl
+      prevSettings.username !== settings.username ||
+      prevSettings.password !== settings.password ||
+      prevSettings.sourceUrl !== settings.sourceUrl
     ) {
       this.setState(
         { readings: [], value: 0, apiUrls: null, response: 'Loading...' },
@@ -90,7 +90,7 @@ class PlotView extends Component<Props, State> {
     this.lastTimeoutId = 0;
   };
 
-  getApiUrls = async (sourceUrl: string): Promise<any> => {
+  getApiUrls = async (sourceUrl: string): Promise<IApiUrl> => {
     return new Promise(async (resolve, reject) => {
       try {
         console.log(`Requesting from ${sourceUrl}`);
@@ -121,7 +121,7 @@ class PlotView extends Component<Props, State> {
     if (!this.isThisMounted) {
       return;
     }
-    const { username, password, sourceUrl } = this.props.state;
+    const { username, password, sourceUrl } = this.props.settings;
     const usingTestApi = isTestApi(sourceUrl);
     if (!sourceUrl) {
       this.setState({ response: 'Need source!' });
@@ -140,7 +140,7 @@ class PlotView extends Component<Props, State> {
     try {
       let { apiUrls } = this.state;
       if (!apiUrls) {
-        apiUrls = (await this.getApiUrls(sourceUrl)) as IApiUrl;
+        apiUrls = await this.getApiUrls(sourceUrl);
       }
       const {
         auth: authReq,
@@ -301,7 +301,7 @@ class PlotView extends Component<Props, State> {
 export function WrappedPlotView() {
   const { settings } = useSettingsContext();
   const navigation = useNavigation();
-  return <PlotView state={settings} navigation={navigation} />;
+  return <PlotView settings={settings} navigation={navigation} />;
 }
 
 const styles = StyleSheet.create({

--- a/src/PlotView/PlotView.tsx
+++ b/src/PlotView/PlotView.tsx
@@ -25,8 +25,6 @@ interface Props {
 }
 
 interface State {
-  timeSinceLastReadingInSeconds: number | undefined;
-  readingIsOld: boolean | undefined;
   readings?: IPlotDatum[];
   response: string;
   plotWidth: number;
@@ -43,8 +41,6 @@ class PlotView extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      timeSinceLastReadingInSeconds: undefined,
-      readingIsOld: undefined,
       response: '',
       plotSettings: DEFAULT_META,
       plotWidth: 100,
@@ -120,8 +116,6 @@ class PlotView extends Component<Props, State> {
       }
       this.setState({
         response: 'Success',
-        timeSinceLastReadingInSeconds,
-        readingIsOld: readingIsOld,
         readings,
         plotSettings: meta,
       });
@@ -153,16 +147,12 @@ class PlotView extends Component<Props, State> {
   };
 
   render() {
-    const {
-      readings,
-      response,
-      readingIsOld,
-      plotWidth,
-      plotHeight,
-      plotSettings,
-    } = this.state;
+    const { readings, response, plotWidth, plotHeight, plotSettings } =
+      this.state;
     const [latestReading] = readings ?? [];
     const { Trend: trend, Value: latestValue } = latestReading ?? {};
+    const readingIsOld =
+      latestReading && extractDate(latestReading)?.readingIsOld;
     return (
       <View
         style={styles.container}

--- a/src/PlotView/PlotView.tsx
+++ b/src/PlotView/PlotView.tsx
@@ -276,8 +276,7 @@ export function WrappedPlotView() {
     queryKey: [sourceUrl, 'urls.json'],
     queryFn: async () => {
       console.log(`Requesting from ${sourceUrl}`);
-      const lastUrl = `${sourceUrl}/urls.json`;
-      const response = await fetch(lastUrl);
+      const response = await fetch(`${sourceUrl}/urls.json`);
       const { status, ok } = response;
       if (!ok) {
         const apiError = await response.text();

--- a/src/PlotView/PlotView.tsx
+++ b/src/PlotView/PlotView.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 
 import { COLORS } from '../common/colors';
@@ -25,64 +25,58 @@ interface Props {
   logContent: string;
 }
 
-interface State {
+interface IPlotDimensions {
   plotWidth: number;
   plotHeight: number;
 }
 
-class PlotView extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      plotWidth: 0,
-      plotHeight: 0,
-    };
-  }
-
-  render() {
-    const { readings, plotSettings, logContent } = this.props;
-    const { plotWidth, plotHeight } = this.state;
-    const [latestReading] = readings ?? [];
-    const { Trend: trend, Value: latestValue } = latestReading ?? {};
-    const readingIsOld =
-      latestReading && extractDate(latestReading)?.readingIsOld;
-    return (
-      <View
-        style={styles.container}
-        onLayout={(event) => {
-          const { width, height } = event.nativeEvent.layout;
-          this.setState({ plotWidth: width, plotHeight: height });
-        }}>
-        {plotWidth > plotMarginX2 && plotHeight > plotMarginX2 && (
-          <View
-            style={{
-              ...styles.overlay,
-              width: plotWidth - plotMarginX2,
-              height: plotHeight - plotMarginX2,
-            }}>
-            <GlucoseGraph
-              width={plotWidth - plotMarginX2}
-              height={plotHeight - plotMarginX2}
-              readings={readings}
-              plotSettings={plotSettings}
-            />
-            <Text style={styles.overlayContent}>Loading...</Text>
-          </View>
-        )}
-        <Overlay
-          width={plotWidth}
-          height={plotHeight}
-          value={latestValue}
-          trend={trend}
-          readingIsOld={readingIsOld ?? false}
-        />
-        <Text style={styles.logContent}>
-          {logContent}
-          {readingIsOld && ' Outdated Reading'}
-        </Text>
-      </View>
-    );
-  }
+function PlotView(props: Props) {
+  const [plotDimensions, setPlotDimensions] = useState<IPlotDimensions>({
+    plotWidth: 0,
+    plotHeight: 0,
+  });
+  const { plotWidth, plotHeight } = plotDimensions;
+  const { readings, plotSettings, logContent } = props;
+  const [latestReading] = readings ?? [];
+  const { Trend: trend, Value: latestValue } = latestReading ?? {};
+  const readingIsOld =
+    latestReading && extractDate(latestReading)?.readingIsOld;
+  return (
+    <View
+      style={styles.container}
+      onLayout={(event) => {
+        const { width, height } = event.nativeEvent.layout;
+        setPlotDimensions({ plotWidth: width, plotHeight: height });
+      }}>
+      {plotWidth > plotMarginX2 && plotHeight > plotMarginX2 && (
+        <View
+          style={{
+            ...styles.overlay,
+            width: plotWidth - plotMarginX2,
+            height: plotHeight - plotMarginX2,
+          }}>
+          <GlucoseGraph
+            width={plotWidth - plotMarginX2}
+            height={plotHeight - plotMarginX2}
+            readings={readings}
+            plotSettings={plotSettings}
+          />
+          <Text style={styles.overlayContent}>Loading...</Text>
+        </View>
+      )}
+      <Overlay
+        width={plotWidth}
+        height={plotHeight}
+        value={latestValue}
+        trend={trend}
+        readingIsOld={readingIsOld ?? false}
+      />
+      <Text style={styles.logContent}>
+        {logContent}
+        {readingIsOld && ' Outdated Reading'}
+      </Text>
+    </View>
+  );
 }
 
 export function WrappedPlotView() {
@@ -197,6 +191,7 @@ export function WrappedPlotView() {
       if (apiIsTestUrl) {
         updateTestReadingDateTimes(apiReadings);
       }
+      console.debug('Latest Reading', apiReadings[0]);
       return apiReadings;
     },
     onSuccess: (data) => {

--- a/src/PlotView/PlotView.tsx
+++ b/src/PlotView/PlotView.tsx
@@ -31,8 +31,8 @@ interface State {
   readings?: IPlotDatum[];
   lastUrl: string;
   response: string;
-  width: number;
-  height: number;
+  plotWidth: number;
+  plotHeight: number;
   plotSettings: IPlotSettings;
 }
 
@@ -53,8 +53,8 @@ class PlotView extends Component<Props, State> {
       lastUrl: '',
       response: '',
       plotSettings: DEFAULT_META,
-      width: 100,
-      height: 100,
+      plotWidth: 100,
+      plotHeight: 100,
     };
     this.authKey = '';
     this.lastUpdatedAuthKey = 0;
@@ -224,8 +224,8 @@ class PlotView extends Component<Props, State> {
       lastUrl,
       response,
       isOldReading,
-      width,
-      height,
+      plotWidth,
+      plotHeight,
       plotSettings,
     } = this.state;
     return (
@@ -233,18 +233,18 @@ class PlotView extends Component<Props, State> {
         style={styles.container}
         onLayout={(event) => {
           const { width, height } = event.nativeEvent.layout;
-          this.setState({ width, height });
+          this.setState({ plotWidth: width, plotHeight: height });
         }}>
-        {width > plotMarginX2 && height > plotMarginX2 && (
+        {plotWidth > plotMarginX2 && plotHeight > plotMarginX2 && (
           <View
             style={{
               ...styles.overlay,
-              width: width - plotMarginX2,
-              height: height - plotMarginX2,
+              width: plotWidth - plotMarginX2,
+              height: plotHeight - plotMarginX2,
             }}>
             <GlucoseGraph
-              width={width - plotMarginX2}
-              height={height - plotMarginX2}
+              width={plotWidth - plotMarginX2}
+              height={plotHeight - plotMarginX2}
               readings={readings}
               plotSettings={plotSettings}
             />
@@ -252,8 +252,8 @@ class PlotView extends Component<Props, State> {
           </View>
         )}
         <Overlay
-          width={width}
-          height={height}
+          width={plotWidth}
+          height={plotHeight}
           value={value}
           trend={trend}
           isOldReading={isOldReading ?? false}

--- a/src/PlotView/components/GlucoseGraph.tsx
+++ b/src/PlotView/components/GlucoseGraph.tsx
@@ -1,4 +1,4 @@
-import { Component, Fragment } from 'react';
+import { Fragment } from 'react';
 import Svg, { Circle, Rect } from 'react-native-svg';
 import { AxisLine } from './AxisLine';
 import { VertAxisLine } from './VertAxisLine';
@@ -17,130 +17,128 @@ interface Props {
 
 const FUTURE_TIME_IN_SECONDS = 40 * 60;
 
-export class GlucoseGraph extends Component<Props> {
-  render() {
-    const { width, height, readings, plotSettings } = this.props;
-    if (!width || !height || !readings || !readings.length || !plotSettings) {
-      return null;
-    }
-    const {
-      minScale, //: 30,
-      lowAxis, //: 70,
-      highAxis, //: 140,
-      higherAxis, //: 160,
-      maxScale, //: 250,
-      units, // 'mg/dL'
-    } = plotSettings;
-    const calcTimePosition = (value: number) => {
-      if (width < 300) {
-        // Leave enough space for 20 minutes of future data.
-        return width - (value + FUTURE_TIME_IN_SECONDS / 2) / 20;
-      }
-      // Leave enough space for 40 minutes of future data.
-      return width - (value + FUTURE_TIME_IN_SECONDS) / 20;
-    };
-    const calcValuePosition = (value: number) => {
-      let heightRatio = 1 - (value - minScale) / (maxScale - minScale);
-      heightRatio = Math.max(0, heightRatio);
-      heightRatio = Math.min(1, heightRatio);
-      return height * heightRatio;
-    };
-    const readingData = readings.map(extractData.bind(null, plotSettings));
-    const [lastReadingDatum] = readingData;
-    const { color: lastReadingColor, isInRange } = lastReadingDatum;
-    const projectedReadings = projectReadings(readingData, highAxis);
-    const dateAxisValues = [];
-    const now = Date.now();
-    for (let i = 0; i <= 5 * 60; i += 60) {
-      dateAxisValues.push({
-        x: calcTimePosition(i * 60),
-        value: format(subMinutes(now, i), 'hh:mm a'),
-      });
-    }
-    return (
-      <Svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
-        <Rect
-          x={0}
-          y={0}
-          width={width}
-          height={height}
-          stroke={lastReadingColor}
-          strokeWidth={isInRange ? 1 : 6}
-          fill="none"
-          opacity={isInRange ? 0.2 : 0.5}
-        />
-        <AxisLine
-          y={calcValuePosition(lowAxis)}
-          units={units}
-          width={width}
-          color="red"
-          value={lowAxis}
-        />
-        <AxisLine
-          y={calcValuePosition(highAxis)}
-          units={units}
-          width={width}
-          color="#666"
-          value={highAxis}
-        />
-        <AxisLine
-          y={calcValuePosition(higherAxis)}
-          units={units}
-          width={width}
-          color="yellow"
-          value={higherAxis}
-        />
-        {[...readingData, ...projectedReadings].map((datum, index) => {
-          const {
-            value,
-            timeSinceLastReadingInSeconds = 0,
-            color,
-            isProjected,
-            projectedIndex,
-            opacity = 1.0,
-          } = datum;
-          const x = calcTimePosition(timeSinceLastReadingInSeconds);
-          const y = calcValuePosition(value);
-          const textAnchor = (width - x) / width < 0.1 ? 'end' : 'middle';
-          return (
-            <Fragment key={index}>
-              <Circle
-                cx={x}
-                cy={y}
-                r="5"
-                stroke={isProjected ? color : 'white'}
-                strokeWidth="1.5"
-                fill={color}
-                opacity={opacity}
-              />
-              {(projectedIndex === 5 || (!isProjected && index % 5 === 0)) && (
-                <SvgText
-                  x={x}
-                  y={y}
-                  color={color}
-                  textAnchor={textAnchor}
-                  opacity={isProjected ? 0.8 : 1.0}
-                  yOffset={8}
-                  fontSize={16}>
-                  {value}
-                </SvgText>
-              )}
-            </Fragment>
-          );
-        })}
-        {dateAxisValues.map((axis) => {
-          const { x, value } = axis;
-          return (
-            <VertAxisLine
-              key={x}
-              x={x}
-              height={height}
-              color="#666"
-              value={value}
-            />
-          );
-        })}
-      </Svg>
-    );
+export function GlucoseGraph(props: Props) {
+  const { width, height, readings, plotSettings } = props;
+  if (!width || !height || !readings || !readings.length || !plotSettings) {
+    return null;
   }
+  const {
+    minScale, //: 30,
+    lowAxis, //: 70,
+    highAxis, //: 140,
+    higherAxis, //: 160,
+    maxScale, //: 250,
+    units, // 'mg/dL'
+  } = plotSettings;
+  const calcTimePosition = (value: number) => {
+    if (width < 300) {
+      // Leave enough space for 20 minutes of future data.
+      return width - (value + FUTURE_TIME_IN_SECONDS / 2) / 20;
+    }
+    // Leave enough space for 40 minutes of future data.
+    return width - (value + FUTURE_TIME_IN_SECONDS) / 20;
+  };
+  const calcValuePosition = (value: number) => {
+    let heightRatio = 1 - (value - minScale) / (maxScale - minScale);
+    heightRatio = Math.max(0, heightRatio);
+    heightRatio = Math.min(1, heightRatio);
+    return height * heightRatio;
+  };
+  const readingData = readings.map(extractData.bind(null, plotSettings));
+  const [lastReadingDatum] = readingData;
+  const { color: lastReadingColor, isInRange } = lastReadingDatum;
+  const projectedReadings = projectReadings(readingData, highAxis);
+  const dateAxisValues = [];
+  const now = Date.now();
+  for (let i = 0; i <= 5 * 60; i += 60) {
+    dateAxisValues.push({
+      x: calcTimePosition(i * 60),
+      value: format(subMinutes(now, i), 'hh:mm a'),
+    });
+  }
+  return (
+    <Svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+      <Rect
+        x={0}
+        y={0}
+        width={width}
+        height={height}
+        stroke={lastReadingColor}
+        strokeWidth={isInRange ? 1 : 6}
+        fill="none"
+        opacity={isInRange ? 0.2 : 0.5}
+      />
+      <AxisLine
+        y={calcValuePosition(lowAxis)}
+        units={units}
+        width={width}
+        color="red"
+        value={lowAxis}
+      />
+      <AxisLine
+        y={calcValuePosition(highAxis)}
+        units={units}
+        width={width}
+        color="#666"
+        value={highAxis}
+      />
+      <AxisLine
+        y={calcValuePosition(higherAxis)}
+        units={units}
+        width={width}
+        color="yellow"
+        value={higherAxis}
+      />
+      {[...readingData, ...projectedReadings].map((datum, index) => {
+        const {
+          value,
+          timeSinceLastReadingInSeconds = 0,
+          color,
+          isProjected,
+          projectedIndex,
+          opacity = 1.0,
+        } = datum;
+        const x = calcTimePosition(timeSinceLastReadingInSeconds);
+        const y = calcValuePosition(value);
+        const textAnchor = (width - x) / width < 0.1 ? 'end' : 'middle';
+        return (
+          <Fragment key={index}>
+            <Circle
+              cx={x}
+              cy={y}
+              r="5"
+              stroke={isProjected ? color : 'white'}
+              strokeWidth="1.5"
+              fill={color}
+              opacity={opacity}
+            />
+            {(projectedIndex === 5 || (!isProjected && index % 5 === 0)) && (
+              <SvgText
+                x={x}
+                y={y}
+                color={color}
+                textAnchor={textAnchor}
+                opacity={isProjected ? 0.8 : 1.0}
+                yOffset={8}
+                fontSize={16}>
+                {value}
+              </SvgText>
+            )}
+          </Fragment>
+        );
+      })}
+      {dateAxisValues.map((axis) => {
+        const { x, value } = axis;
+        return (
+          <VertAxisLine
+            key={x}
+            x={x}
+            height={height}
+            color="#666"
+            value={value}
+          />
+        );
+      })}
+    </Svg>
+  );
 }

--- a/src/PlotView/components/Overlay.tsx
+++ b/src/PlotView/components/Overlay.tsx
@@ -9,14 +9,15 @@ import { getIconName } from '../utils';
 interface Props {
   value: number;
   trend: number | Trend;
-  isOldReading: boolean;
+  readingIsOld: boolean;
   width: number;
   height: number;
 }
 
 export function Overlay(props: Props) {
-  const { width, height, value, trend, isOldReading } = props;
-  const isLarge = width > 480 && height > 360;
+  const { width, height, value, trend, readingIsOld } = props;
+  const widthIsLarge = width > 480 && height > 360;
+  const iconSize = widthIsLarge ? 120 : 60;
   return (
     <ScrollView style={styles.innerContainer}>
       <Text
@@ -24,15 +25,15 @@ export function Overlay(props: Props) {
           // eslint-disable-next-line react-native/no-inline-styles
           {
             ...styles.value,
-            fontSize: 180 - (isLarge ? 0 : 80),
-            color: isOldReading ? '#666' : COLORS.primary,
+            fontSize: 180 - (widthIsLarge ? 0 : 80),
+            color: readingIsOld ? '#666' : COLORS.primary,
           }
         }>
         {value ? value : '-'}{' '}
-        {isOldReading && <Icon name="help" size={isLarge ? 120 : 60} />}
-        <Icon name={getIconName(trend)} size={isLarge ? 120 : 60} />
+        {readingIsOld && <Icon name="help" size={iconSize} />}
+        <Icon name={getIconName(trend)} size={iconSize} />
         {(trend === 1 || trend === 7) && (
-          <Icon name={getIconName()} size={isLarge ? 120 : 60} />
+          <Icon name={getIconName()} size={iconSize} />
         )}
       </Text>
     </ScrollView>

--- a/src/PlotView/types.ts
+++ b/src/PlotView/types.ts
@@ -21,7 +21,7 @@ export interface IPlotDatumDateProps {
   timeInSeconds?: number;
   timeSinceLastReadingInSeconds?: number;
   timeSinceLastReadingInMinutes?: number;
-  isOldReading?: boolean;
+  readingIsOld?: boolean;
   date?: Date;
 }
 

--- a/src/PlotView/utils.ts
+++ b/src/PlotView/utils.ts
@@ -14,13 +14,13 @@ export function extractDate(reading: IPlotDatum): IPlotDatumDateProps | null {
     const timeInSeconds = timeInMilliseconds / 1000;
     const timeSinceLastReadingInSeconds = Date.now() / 1000 - timeInSeconds;
     const timeSinceLastReadingInMinutes = timeSinceLastReadingInSeconds / 60;
-    const isOldReading = timeSinceLastReadingInSeconds > 10 * 60;
+    const readingIsOld = timeSinceLastReadingInSeconds > 10 * 60;
     return {
       timeInMilliseconds,
       timeInSeconds,
       timeSinceLastReadingInSeconds,
       timeSinceLastReadingInMinutes,
-      isOldReading,
+      readingIsOld,
       date: new Date(timeInMilliseconds),
     };
   }
@@ -78,14 +78,14 @@ export function getIconName(trend?: Trend | number) {
 }
 
 export function updateTestReadingDateTimes(readings: IPlotDatum[]) {
-  const [firstReading] = readings;
-  const firstReadingDate = extractDate(firstReading);
+  const [latestReading] = readings;
+  const latestReadingDate = extractDate(latestReading);
   readings.forEach((reading: IPlotDatum) => {
     const readingDate = extractDate(reading);
     const updatedTimeInMilliseconds =
       Date.now() +
       (readingDate?.timeInMilliseconds ?? 0) -
-      (firstReadingDate?.timeInMilliseconds ?? 0);
+      (latestReadingDate?.timeInMilliseconds ?? 0);
     reading.ST = `/Date(${updatedTimeInMilliseconds})/`;
   });
 }

--- a/src/PlotView/utils.ts
+++ b/src/PlotView/utils.ts
@@ -6,7 +6,12 @@ import {
   Trend,
 } from './types';
 
-export function extractDate(reading: IPlotDatum): IPlotDatumDateProps | null {
+export function extractDate(
+  reading: IPlotDatum | undefined,
+): IPlotDatumDateProps | null {
+  if (!reading) {
+    return null;
+  }
   const { ST: serverTimeString } = reading;
   const matches = /Date\(([0-9]*)\)/.exec(serverTimeString);
   if (matches) {

--- a/src/PlotView/utils.ts
+++ b/src/PlotView/utils.ts
@@ -76,3 +76,16 @@ export function getIconName(trend?: Trend | number) {
       return 'help';
   }
 }
+
+export function updateTestReadingDateTimes(readings: IPlotDatum[]) {
+  const [firstReading] = readings;
+  const firstReadingDate = extractDate(firstReading);
+  readings.forEach((reading: IPlotDatum) => {
+    const readingDate = extractDate(reading);
+    const updatedTimeInMilliseconds =
+      Date.now() +
+      (readingDate?.timeInMilliseconds ?? 0) -
+      (firstReadingDate?.timeInMilliseconds ?? 0);
+    reading.ST = `/Date(${updatedTimeInMilliseconds})/`;
+  });
+}


### PR DESCRIPTION
Rename props.state to props.settings
Extract apiUrls retrieval to useQuery
Refactor shadowed variables to be more clear
Clean up a variable
Extract auth to useQuery

Refactor more PlotView 
----
* Add API type
* Extract utility function
* Remove unneeded code

Refactor terminology, clean up state 
-----
* Rename to `readingIsOld`
* Remove some props from `state`
 
Remove lastUrl from state
Clean up more state values
Remove unneeded navigation
Rename log content to logContent

Refactor to remove derived props from state 
----
`plotSettings` are derived from `apiUrls`
Make that be always defined, and extract directly.

Convert data API read to useQuery 
Convert PlotView to function component 
----
* Convert and move state to `useState`

Remove unused import
 
Convert last class component to function component
