### PR TITLE
Adjust reading query key

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -98,8 +98,8 @@ android {
         applicationId "com.jazeee"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 18
-        versionName "2.1.1"
+        versionCode 19
+        versionName "2.1.2"
     }
 
     splits {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jazeee",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jazeee",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dependencies": {
         "@react-native-async-storage/async-storage": "1.18.1",
         "@react-navigation/native": "6.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "JazCom Data Viewer - Plot data from API every 5 minutes or so.",
   "name": "jazeee",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -1,12 +1,13 @@
 import { useNavigation } from '@react-navigation/native';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { COLORS } from '../common/colors';
+import { version } from '../../package.json';
 
 export function Home() {
   const { navigate } = useNavigation();
   return (
     <View style={styles.container}>
-      <Text style={styles.welcome}>Jazeee Data Monitor v2.1.1</Text>
+      <Text style={styles.welcome}>Jazeee Data Monitor v{version}</Text>
       <Text style={styles.description}>
         This application reads data from an API and displays it in an always-on
         graph.

--- a/src/PlotView/useReadings.ts
+++ b/src/PlotView/useReadings.ts
@@ -86,7 +86,16 @@ export function useReadings() {
     error: readingsError,
   } = useQuery<IPlotDatum[], Error, IPlotDatum[], string[]>({
     enabled: Boolean(dataUrl) && Boolean(authKey),
-    queryKey: ['readingDataApi', dataUrl ?? '', authKey ?? ''],
+    queryKey: [
+      'readingDataApi',
+      dataUrl ?? '',
+      /**
+       * The authKey changes every 45 minutes or so. We don't care if
+       * it changes, as long as it is defined.
+       * We only want to invalidate query if the authKey is falsy.
+       */
+      authKey ? 'valid-auth-key' : '',
+    ],
     refetchInterval: (data) => {
       let delayToNextRequestInSeconds = 5 * 60;
       if (data) {


### PR DESCRIPTION
The API state for `readings` were being cleared every 45 minutes or so,
since the `useQuery` key included the `authToken` as a dependency.
This causes the UI to flicker every 45 minutes.
Make that dependency be less specific.
Update to `v2.1.2`