### PR TITLE
Add text shadow to overlay

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -98,8 +98,8 @@ android {
         applicationId "com.jazeee"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 19
-        versionName "2.1.2"
+        versionCode 20
+        versionName "2.1.3"
     }
 
     splits {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jazeee",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jazeee",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "dependencies": {
         "@react-native-async-storage/async-storage": "1.18.1",
         "@react-navigation/native": "6.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "JazCom Data Viewer - Plot data from API every 5 minutes or so.",
   "name": "jazeee",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/PlotView/components/Overlay.tsx
+++ b/src/PlotView/components/Overlay.tsx
@@ -45,5 +45,11 @@ const styles = StyleSheet.create({
   value: {
     fontSize: 180,
     color: COLORS.primary,
+    textShadowColor: '#3af',
+    textShadowOffset: {
+      width: 2,
+      height: 2,
+    },
+    textShadowRadius: 8,
   },
 });


### PR DESCRIPTION
When the plot overlaps with the text overlay, the text can be hard to read.

Add a text shadow to the overlay to help distinguish it.
v2.1.3

![image](https://user-images.githubusercontent.com/5629800/230696248-76fda6ac-0c92-46aa-b52e-ff7b0afea407.png)
